### PR TITLE
DPN-626: Ignore subfields in table creation

### DIFF
--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -147,7 +147,8 @@ def get_field_type_schema(field_type):
         return {"type": ["null", "string"]}
 
 def get_field_schema(field_type, extras=False):
-    if extras:
+    # Condition below will need to change if including subfields in table creation
+    if False and extras:  
         return {
             "type": "object",
             "properties": {


### PR DESCRIPTION
JIRA: https://financeit.atlassian.net/browse/DPN-626

# Description of change ([taken from this confluence page](https://financeit.atlassian.net/wiki/spaces/DATA/pages/2470936663/Hubspot+to+Redshift))
Redshift only allows a maximum of 1,600 columns per table. This is a hard-limit. The Contacts object contains roughly 500-600 fields and sub-fields, and most of these fields and sub-fields contain 4 attributes (value, timestamp, source, sourceId), which results in 4 columns per field. Let say we have a field named company. During runtime, Singer will actually try to create 4 columns for this field in Redshift, namely company_value, company_timestamp, company_source and company_sourceId. 

This problem has been reported by other users as well. In [the following article](https://github.com/singer-io/tap-hubspot/issues/119
), another workaround is to directly modify the `__init__.py` script in the tap-hubspot package. By editing line 149 and changing it from `if extras:` to `if False and extras:`, tap-hubspot will ignore the extra 4 attributes during table creation. This will significantly reduce the number of columns being created. 

This approach will be taken as we want to now sync the contacts object and don't require sync of the sub-fields.

# Manual QA steps
 - 
 
# Risks
 - Will need to rethink this condition if we want to sync subfields for other objects
 
# Rollback steps
 - revert this branch
